### PR TITLE
[Bug] 모바일에서 탭을 복원하는 경우, authorization이 정상적으로 이루어지지 않음.

### DIFF
--- a/src/shared/constants/cookies.ts
+++ b/src/shared/constants/cookies.ts
@@ -2,5 +2,5 @@ export const COOKIE_OPTIONS = {
   httpOnly: true,
   path: "/",
   secure: process.env.NODE_ENV === "production",
-  sameSite: "strict",
+  sameSite: "lax",
 } as const;


### PR DESCRIPTION
## Description

### SameSite=Strict의 동작
Strict는 "오직 동일 사이트에서 발생한 요청"에만 쿠키를 전송함.
브라우저가 앱을 완전히 종료했다가 복원할 때, 첫 요청(페이지 복원 시의 자동 요청)을 동일 사이트 내 요청으로 간주하지 않는 경우가 있음.

특히 모바일 브라우저에서는 탭 복원이나 앱 재실행 시, 첫 요청을 "사용자 행동에 의한 탐색"이 아닌 "브라우저 내부의 세션 복원"으로 처리할 수 있음. 이 경우 Strict 쿠키가 전송되지 않음.

페이지를 이동(탑레벨 네비게이션)하면, 그제서야 "명시적 사용자 탐색"으로 인식되어 쿠키가 전송됨.

### SameSite=Lax의 동작
Lax는 "동일 사이트 요청" + "탑레벨 GET 네비게이션"에 쿠키를 전송함.

즉, 사용자가 직접 URL을 입력하거나, 북마크에서 열거나, 앱 재실행 후 자동으로 복원된 탭의 첫 GET 요청 등 탑레벨 네비게이션에도 쿠키가 전송됨.

모바일 브라우저에서 앱을 종료 후 재실행했을 때, 탭 복원 시의 첫 요청이 Lax 조건(탑레벨 GET)에는 포함되어 쿠키가 전송됨.



Fixes: #29