### PR TITLE
AuthorizationRouteHandler HOC 적용

### DIFF
--- a/src/features/copyCoupleLink/ui/CopyCoupleLinkButton.tsx
+++ b/src/features/copyCoupleLink/ui/CopyCoupleLinkButton.tsx
@@ -38,7 +38,7 @@ export default CopyCoupleLinkButton;
 export const LoadingCopyCoupleLinkButton: React.FC = () => {
   return (
     <BottomFloatingButtonWrapper>
-      <Button size={52} variant="default" full disabled data-testid="loading-copy-couple-link-button">
+      <Button type="button" size={52} variant="default" full disabled data-testid="loading-copy-couple-link-button">
         커플 링크 복사하기
       </Button>
     </BottomFloatingButtonWrapper>

--- a/src/features/handleAuthorizationRoute/ui/AuthorizationRouteHandler.tsx
+++ b/src/features/handleAuthorizationRoute/ui/AuthorizationRouteHandler.tsx
@@ -12,12 +12,9 @@ import {
   UNAUTHORIZED_STATUS,
 } from "@/shared/constants/auth";
 
-interface Props {
-  requiredAuth?: boolean;
-  requiredCouple?: boolean;
-  isRestorePage?: boolean;
-  isRegisterPage?: boolean;
-}
+import { AuthorizationConfig } from "./authorizationRoute.interface";
+
+interface Props extends AuthorizationConfig {}
 
 const AuthorizationRouteHandler = async ({
   requiredAuth,

--- a/src/features/handleAuthorizationRoute/ui/__mocks__/index.ts
+++ b/src/features/handleAuthorizationRoute/ui/__mocks__/index.ts
@@ -1,1 +1,0 @@
-export { default as AuthorizationRouteHandler } from "../AuthorizationRouteHandler";

--- a/src/features/handleAuthorizationRoute/ui/authorizationRoute.interface.ts
+++ b/src/features/handleAuthorizationRoute/ui/authorizationRoute.interface.ts
@@ -1,0 +1,6 @@
+export interface AuthorizationConfig {
+  requiredAuth?: boolean;
+  requiredCouple?: boolean;
+  isRestorePage?: boolean;
+  isRegisterPage?: boolean;
+}

--- a/src/features/handleAuthorizationRoute/ui/index.ts
+++ b/src/features/handleAuthorizationRoute/ui/index.ts
@@ -1,3 +1,1 @@
-import dynamic from "next/dynamic";
-
-export const AuthorizationRouteHandler = dynamic(() => import("./AuthorizationRouteHandler"), { loading: () => null });
+export { default as withAuthorizationRoute } from "./withAuthorizationRoute";

--- a/src/features/handleAuthorizationRoute/ui/withAuthorizationRoute.test.tsx
+++ b/src/features/handleAuthorizationRoute/ui/withAuthorizationRoute.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import { expect, test, vi } from "vitest";
+
+import withAuthorizationRoute from "./withAuthorizationRoute";
+
+vi.mock("./AuthorizationRouteHandler", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+interface TestComponentProps {
+  title: string;
+  count: number;
+  isActive?: boolean;
+}
+
+const TestComponent = ({ title, count, isActive = false }: TestComponentProps) => (
+  <div>
+    <h1>{title}</h1>
+    <p>Count: {count}</p>
+    <span>Status: {isActive ? "active" : "inactive"}</span>
+  </div>
+);
+
+test("props를 원본 컴포넌트에 정상적으로 전달한다", () => {
+  const WrappedComponent = withAuthorizationRoute(TestComponent, {
+    requiredAuth: true,
+  });
+
+  const props: TestComponentProps = {
+    title: "테스트 제목",
+    count: 42,
+    isActive: true,
+  };
+
+  render(<WrappedComponent {...props} />);
+
+  expect(screen.getByText("테스트 제목")).toBeInTheDocument();
+  expect(screen.getByText("Count: 42")).toBeInTheDocument();
+  expect(screen.getByText("Status: active")).toBeInTheDocument();
+});
+
+test("optional props를 정상적으로 전달한다", () => {
+  const WrappedComponent = withAuthorizationRoute(TestComponent, {
+    requiredAuth: false,
+  });
+
+  const props = {
+    title: "선택적 props 테스트",
+    count: 10,
+  };
+
+  render(<WrappedComponent {...props} />);
+
+  expect(screen.getByText("선택적 props 테스트")).toBeInTheDocument();
+  expect(screen.getByText("Count: 10")).toBeInTheDocument();
+  expect(screen.getByText("Status: inactive")).toBeInTheDocument();
+});
+
+test("빈 props 객체를 정상적으로 처리한다", () => {
+  const SimpleComponent = () => <div>Simple Component</div>;
+
+  const WrappedComponent = withAuthorizationRoute(SimpleComponent, {
+    requiredCouple: true,
+  });
+
+  render(<WrappedComponent />);
+
+  expect(screen.getByText("Simple Component")).toBeInTheDocument();
+});
+
+test("익명 컴포넌트를 정상적으로 래핑한다", () => {
+  const WrappedComponent = withAuthorizationRoute(() => <div>Anonymous Component</div>, {
+    isRestorePage: true,
+  });
+
+  render(<WrappedComponent />);
+
+  expect(screen.getByText("Anonymous Component")).toBeInTheDocument();
+});

--- a/src/features/handleAuthorizationRoute/ui/withAuthorizationRoute.tsx
+++ b/src/features/handleAuthorizationRoute/ui/withAuthorizationRoute.tsx
@@ -14,6 +14,8 @@ const withAuthorizationRoute = <P extends object>(WrappedComponent: ComponentTyp
     );
   };
 
+  WithAuthorizationRoute.displayName = `WithAuthorizationRoute(${WrappedComponent.displayName || WrappedComponent.name || "Component"})`;
+
   return WithAuthorizationRoute;
 };
 

--- a/src/features/handleAuthorizationRoute/ui/withAuthorizationRoute.tsx
+++ b/src/features/handleAuthorizationRoute/ui/withAuthorizationRoute.tsx
@@ -1,0 +1,20 @@
+import { type ComponentType } from "react";
+
+import AuthorizationRouteHandler from "./AuthorizationRouteHandler";
+
+import type { AuthorizationConfig } from "./authorizationRoute.interface";
+
+const withAuthorizationRoute = <P extends object>(WrappedComponent: ComponentType<P>, config: AuthorizationConfig) => {
+  const WithAuthorizationRoute = (props: P) => {
+    return (
+      <>
+        <WrappedComponent {...props} />
+        <AuthorizationRouteHandler {...config} />
+      </>
+    );
+  };
+
+  return WithAuthorizationRoute;
+};
+
+export default withAuthorizationRoute;

--- a/src/shared/ui/Alert/Alert.stories.tsx
+++ b/src/shared/ui/Alert/Alert.stories.tsx
@@ -20,6 +20,7 @@ const Template = (props: TemplateProps) => {
     <>
       <Button
         variant="default"
+        type="button"
         size={52}
         onClick={() =>
           showAlert({

--- a/src/shared/ui/Tooltip/Tooltip.stories.tsx
+++ b/src/shared/ui/Tooltip/Tooltip.stories.tsx
@@ -9,7 +9,7 @@ import Tooltip from ".";
 const Template = ({ leftPositionBasedOnTail, tooltipContent, isHidden }: ComponentProps<typeof Tooltip>) => {
   return (
     <Tooltip tooltipContent={tooltipContent} leftPositionBasedOnTail={leftPositionBasedOnTail} isHidden={isHidden}>
-      <Button size={52} variant="default">
+      <Button type="button" size={52} variant="default">
         DEFAULT BUTTON
       </Button>
     </Tooltip>

--- a/src/views/Auth/ui/Login/index.tsx
+++ b/src/views/Auth/ui/Login/index.tsx
@@ -1,4 +1,4 @@
-import { AuthorizationRouteHandler } from "@/features/handleAuthorizationRoute/ui";
+import { withAuthorizationRoute } from "@/features/handleAuthorizationRoute/ui";
 import LoginButton, { LoadingLoginButton } from "@/features/login/ui/LoginButton";
 
 import BackButton from "@/shared/ui/BackButton";
@@ -37,9 +37,8 @@ const LoginPage: React.FC = () => {
         </BackButton>
         <BackButton />
       </main>
-      <AuthorizationRouteHandler requiredAuth={false} />
     </DvhHeightLayout>
   );
 };
 
-export default LoginPage;
+export default withAuthorizationRoute(LoginPage, { requiredAuth: false });

--- a/src/views/Auth/ui/OAuthCallback/index.tsx
+++ b/src/views/Auth/ui/OAuthCallback/index.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense } from "react";
 
-import { AuthorizationRouteHandler } from "@/features/handleAuthorizationRoute/ui";
+import { withAuthorizationRoute } from "@/features/handleAuthorizationRoute/ui";
 
 import Loading from "@/shared/ui/Loading";
 
@@ -8,13 +8,10 @@ import Callback from "./Callback";
 
 const OAuthCallbackPage: React.FC = () => {
   return (
-    <>
-      <Suspense fallback={<Loading isShow />}>
-        <Callback />
-      </Suspense>
-      <AuthorizationRouteHandler requiredAuth={false} />
-    </>
+    <Suspense fallback={<Loading isShow />}>
+      <Callback />
+    </Suspense>
   );
 };
 
-export default OAuthCallbackPage;
+export default withAuthorizationRoute(OAuthCallbackPage, { requiredAuth: false });

--- a/src/views/Auth/ui/Register/RegisterPage.tsx
+++ b/src/views/Auth/ui/Register/RegisterPage.tsx
@@ -1,4 +1,4 @@
-import { AuthorizationRouteHandler } from "@/features/handleAuthorizationRoute/ui";
+import { withAuthorizationRoute } from "@/features/handleAuthorizationRoute/ui";
 
 import { getTermsApi } from "@/entities/term/api/term.server";
 
@@ -7,12 +7,7 @@ import RegisterFunnelPage from "./RegisterFunnelPage";
 const RegisterPage: React.FC = () => {
   const termPromise = getTermsApi();
 
-  return (
-    <>
-      <RegisterFunnelPage termPromise={termPromise} />
-      <AuthorizationRouteHandler requiredAuth isRegisterPage />
-    </>
-  );
+  return <RegisterFunnelPage termPromise={termPromise} />;
 };
 
-export default RegisterPage;
+export default withAuthorizationRoute(RegisterPage, { requiredAuth: true, isRegisterPage: true });

--- a/src/views/Couple/ui/CoupleInvitation/index.tsx
+++ b/src/views/Couple/ui/CoupleInvitation/index.tsx
@@ -3,7 +3,7 @@ import { redirect } from "next/navigation";
 
 import Header from "@/widgets/Layout/ui/Header";
 
-import { AuthorizationRouteHandler } from "@/features/handleAuthorizationRoute/ui";
+import { withAuthorizationRoute } from "@/features/handleAuthorizationRoute/ui";
 
 import { getUserProfileByCodeApi } from "@/entities/user/api/user.server";
 
@@ -61,9 +61,8 @@ const CoupleInvitationPage: React.FC<Props> = async ({ params }) => {
           </Link>
         </BottomFloatingButtonWrapper>
       </main>
-      <AuthorizationRouteHandler requiredAuth requiredCouple={false} />
     </DvhHeightLayout>
   );
 };
 
-export default CoupleInvitationPage;
+export default withAuthorizationRoute(CoupleInvitationPage, { requiredAuth: true, requiredCouple: false });

--- a/src/views/Couple/ui/InviteCouple/InviteCouplePage.test.tsx
+++ b/src/views/Couple/ui/InviteCouple/InviteCouplePage.test.tsx
@@ -8,7 +8,7 @@ import { renderWithProviders } from "@/shared/lib/test";
 import InviteCouplePage from ".";
 
 vi.mock("@/features/handleAuthorizationRoute/ui", () => ({
-  AuthorizationRouteHandler: vi.fn().mockReturnValue(null),
+  withAuthorizationRoute: vi.fn().mockImplementation((Component) => Component),
 }));
 
 afterEach(() => {

--- a/src/views/Couple/ui/InviteCouple/index.tsx
+++ b/src/views/Couple/ui/InviteCouple/index.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import Header from "@/widgets/Layout/ui/Header";
 
 import CopyCoupleLinkButton, { LoadingCopyCoupleLinkButton } from "@/features/copyCoupleLink/ui/CopyCoupleLinkButton";
-import { AuthorizationRouteHandler } from "@/features/handleAuthorizationRoute/ui";
+import { withAuthorizationRoute } from "@/features/handleAuthorizationRoute/ui";
 
 import { getMeApi } from "@/entities/user/api/user.server";
 
@@ -40,9 +40,8 @@ const InviteCouplePage: React.FC = () => {
           {([{ data: me }]) => <CopyCoupleLinkButton code={me.code} />}
         </FetchBoundary>
       </Suspense>
-      <AuthorizationRouteHandler requiredAuth requiredCouple={false} />
     </DvhHeightLayout>
   );
 };
 
-export default InviteCouplePage;
+export default withAuthorizationRoute(InviteCouplePage, { requiredAuth: true, requiredCouple: false });

--- a/src/views/Couple/ui/OurStart/index.tsx
+++ b/src/views/Couple/ui/OurStart/index.tsx
@@ -1,7 +1,7 @@
 import Header from "@/widgets/Layout/ui/Header";
 
 import ConnectCoupleForm from "@/features/connectCouple/ui/ConnectCoupleForm";
-import { AuthorizationRouteHandler } from "@/features/handleAuthorizationRoute/ui";
+import { withAuthorizationRoute } from "@/features/handleAuthorizationRoute/ui";
 
 import BackButton from "@/shared/ui/BackButton";
 
@@ -17,19 +17,16 @@ const OurStartPage: React.FC<Props> = async ({ params }) => {
   const partnerCode = (await params).partnerCode;
 
   return (
-    <>
-      <main className={styles.wrapper}>
-        <Header className={styles.header}>
-          <BackButton className={styles.backButton}>
-            <IconArrowLeft24 />
-          </BackButton>
-          <h2 className={styles.title}>우리의 시작</h2>
-        </Header>
-        <ConnectCoupleForm partnerCode={partnerCode} />
-      </main>
-      <AuthorizationRouteHandler requiredAuth requiredCouple={false} />
-    </>
+    <main className={styles.wrapper}>
+      <Header className={styles.header}>
+        <BackButton className={styles.backButton}>
+          <IconArrowLeft24 />
+        </BackButton>
+        <h2 className={styles.title}>우리의 시작</h2>
+      </Header>
+      <ConnectCoupleForm partnerCode={partnerCode} />
+    </main>
   );
 };
 
-export default OurStartPage;
+export default withAuthorizationRoute(OurStartPage, { requiredAuth: true, requiredCouple: false });

--- a/src/views/Home/ui/index.tsx
+++ b/src/views/Home/ui/index.tsx
@@ -5,7 +5,6 @@ import BottomNavigation from "@/widgets/Layout/ui/BottomNavigation";
 import GNB from "@/widgets/Layout/ui/GNB";
 
 import RequireAuthorizationWrapper from "@/features/checkAuthorization/ui/RequireAuthorizationWrapper";
-import { AuthorizationRouteHandler } from "@/features/handleAuthorizationRoute/ui";
 
 import { getCategoriesApi } from "@/entities/category/api/category.server";
 import ScheduleCard from "@/entities/schedule/ui/ScheduleCard";
@@ -17,7 +16,7 @@ import Test from "./Test";
 
 import styles from "./index.module.scss";
 
-export default async function Home() {
+async function Home() {
   return (
     <main className={styles.wrapper}>
       <GNB />
@@ -49,7 +48,8 @@ export default async function Home() {
         </Suspense>
       </div>
       <BottomNavigation />
-      <AuthorizationRouteHandler />
     </main>
   );
 }
+
+export default Home;

--- a/src/views/NotFound/ui/index.tsx
+++ b/src/views/NotFound/ui/index.tsx
@@ -12,7 +12,7 @@ const NotFoundPage: React.FC = () => {
         <h2 className={styles.title}>404 페이지</h2>
         <p className={styles.description}>디자이너님이 디자인 해주실거에요</p>
         <Link href="/">
-          <Button size={52} variant="default">
+          <Button type="button" size={52} variant="default">
             홈으로 돌아가기
           </Button>
         </Link>

--- a/src/views/User/ui/Restore/RestoreCompletePage.tsx
+++ b/src/views/User/ui/Restore/RestoreCompletePage.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 import Header from "@/widgets/Layout/ui/Header";
 
-import { AuthorizationRouteHandler } from "@/features/handleAuthorizationRoute/ui";
+import { withAuthorizationRoute } from "@/features/handleAuthorizationRoute/ui";
 
 import BottomFloatingButtonWrapper from "@/shared/ui/BottomFloatingButtonWrapper";
 import Button from "@/shared/ui/Button/Button";
@@ -35,9 +35,8 @@ const RestorePage: React.FC = () => {
           </Link>
         </BottomFloatingButtonWrapper>
       </main>
-      <AuthorizationRouteHandler requiredAuth />
     </DvhHeightLayout>
   );
 };
 
-export default RestorePage;
+export default withAuthorizationRoute(RestorePage, { requiredAuth: true });

--- a/src/views/User/ui/Restore/RestorePage.tsx
+++ b/src/views/User/ui/Restore/RestorePage.tsx
@@ -1,6 +1,6 @@
 import Header from "@/widgets/Layout/ui/Header";
 
-import { AuthorizationRouteHandler } from "@/features/handleAuthorizationRoute/ui";
+import { withAuthorizationRoute } from "@/features/handleAuthorizationRoute/ui";
 import RestoreUserButton from "@/features/restoreUser/ui/RestoreUserButton";
 
 import DvhHeightLayout from "@/shared/ui/Layout/DvhHeightLayout";
@@ -26,9 +26,8 @@ const RestorePage: React.FC = () => {
         </section>
         <RestoreUserButton />
       </main>
-      <AuthorizationRouteHandler isRestorePage requiredAuth />
     </DvhHeightLayout>
   );
 };
 
-export default RestorePage;
+export default withAuthorizationRoute(RestorePage, { isRestorePage: true, requiredAuth: true });


### PR DESCRIPTION
Closes: #43

## Features
- `AuthorizationRouteHandler`를 tsx 단에서 렌더링하지 않고, page export 시 사용할 수 있도록 HOC 함수 작성.

## Description
`AuthorizationRouteHandler`를 사용하여 페이지 작업을 하며, 권한 체크 로직이 tsx단 안에 렌더링되고 있어 해당 페이지의 접근 필요 권한이 무엇인지 한눈에 알아보기 힘들다는 것을 느낌.
그에 따른 HOC 처리 방식의 함수 `withAuthorizationRoute` 개발

### AS-IS
```tsx
// 로그인 완료 및 커플인 사람만 접속 가능한 경우
const Component: React.FC = () => {
  ...
  return (
    <>
      ...
      <AuthorizationHandler requiredAuth requiredCouple />
    </>
  )
}

export default Component;
```

### TO-BE
```tsx
// 로그인 완료 및 커플인 사람만 접속 가능한 경우
const Component: React.FC = () => {
  ...
  return (
    <>
      ...
    </>
  )
}

export default withAuthorizationRoute(Component, { requiredAuth: true, requiredCouple: true });
```